### PR TITLE
Broken links for all orgId's (except 1)

### DIFF
--- a/dashboards/ChargingCostsStats.json
+++ b/dashboards/ChargingCostsStats.json
@@ -2530,7 +2530,7 @@
                   {
                     "targetBlank": true,
                     "title": "Trip",
-                    "url": "d/FkUpJpQZk/trip?orgId=1&from=${__data.fields.date_from}&to=${__data.fields.date_to}&var-car_id=$car_id"
+                    "url": "d/FkUpJpQZk/trip?from=${__data.fields.date_from}&to=${__data.fields.date_to}&var-car_id=$car_id"
                   }
                 ]
               },
@@ -2599,7 +2599,7 @@
                   {
                     "targetBlank": true,
                     "title": "Charging stats",
-                    "url": "d/-pkIkhmRz/charging-stats?orgId=1&from=${__data.fields.date_from}&to=${__data.fields.date_to}&var-car_id=$car_id"
+                    "url": "d/-pkIkhmRz/charging-stats?from=${__data.fields.date_from}&to=${__data.fields.date_to}&var-car_id=$car_id"
                   }
                 ]
               },
@@ -2661,7 +2661,7 @@
                   {
                     "targetBlank": true,
                     "title": "Charges",
-                    "url": "d/TSmNYvRRk/charges?orgId=1&from=${__data.fields.date_from}&to=${__data.fields.date_to}&var-car_id=$car_id"
+                    "url": "d/TSmNYvRRk/charges?from=${__data.fields.date_from}&to=${__data.fields.date_to}&var-car_id=$car_id"
                   }
                 ]
               },
@@ -2683,7 +2683,7 @@
                   {
                     "targetBlank": true,
                     "title": "Drives",
-                    "url": "d/Y8upc6ZRk/drives?orgId=1&from=${__data.fields.date_from}&to=${__data.fields.date_to}&var-car_id=$car_id"
+                    "url": "d/Y8upc6ZRk/drives?from=${__data.fields.date_from}&to=${__data.fields.date_to}&var-car_id=$car_id"
                   }
                 ]
               }

--- a/dashboards/CurrentChargeView.json
+++ b/dashboards/CurrentChargeView.json
@@ -110,7 +110,7 @@
       "title": "Current Charge",
       "tooltip": "Show Current Charge Data",
       "type": "link",
-      "url": "d/jchm9RxutVS7a/current-charge-view?orgId=1&kiosk&var-car_id=${car_id}&from=${current_charge_time}&to=${current_end_time}&var-BatteryCapacity=${BatteryCapacity}&var-charging_processes=${charging_processes}"
+      "url": "d/jchm9RxutVS7a/current-charge-view?kiosk&var-car_id=${car_id}&from=${current_charge_time}&to=${current_end_time}&var-BatteryCapacity=${BatteryCapacity}&var-charging_processes=${charging_processes}"
     }
   ],
   "liveNow": false,

--- a/dashboards/CurrentDriveView.json
+++ b/dashboards/CurrentDriveView.json
@@ -112,7 +112,7 @@
       "title": "Current Drive",
       "tooltip": "Adjust to current drive",
       "type": "link",
-      "url": "d/jchmkOuP_Fggz/current-drive-view?orgId=1&kiosk&var-car_id=${car_id}&from=${current_drive_start_time}&to=${current_drive_end_time}&var-current_drive=${current_drive}&var-BatteryCapacity=${BatteryCapacity}&var-efficiency=${efficiency}&var-preferred_range=${preferred_range}"
+      "url": "d/jchmkOuP_Fggz/current-drive-view?kiosk&var-car_id=${car_id}&from=${current_drive_start_time}&to=${current_drive_end_time}&var-current_drive=${current_drive}&var-BatteryCapacity=${BatteryCapacity}&var-efficiency=${efficiency}&var-preferred_range=${preferred_range}"
     }
   ],
   "liveNow": false,

--- a/dashboards/MileageStats.json
+++ b/dashboards/MileageStats.json
@@ -174,7 +174,7 @@
                   {
                     "targetBlank": true,
                     "title": "Trip",
-                    "url": "d/FkUpJpQZk/trip?orgId=1&from=${__data.fields.date_from}&to=${__data.fields.date_to}&var-car_id=$car_id"
+                    "url": "d/FkUpJpQZk/trip?from=${__data.fields.date_from}&to=${__data.fields.date_to}&var-car_id=$car_id"
                   }
                 ]
               }
@@ -223,7 +223,7 @@
                   {
                     "targetBlank": true,
                     "title": "Drives",
-                    "url": "d/Y8upc6ZRk/drives?orgId=1&from=${__data.fields.date_from}&to=${__data.fields.date_to}&var-car_id=$car_id"
+                    "url": "d/Y8upc6ZRk/drives?from=${__data.fields.date_from}&to=${__data.fields.date_to}&var-car_id=$car_id"
                   }
                 ]
               },


### PR DESCRIPTION
The orgId=1 is hardcoded in some links. URL fails when my user's organization is > 1.